### PR TITLE
[FR] Add support for configurable tests and validation

### DIFF
--- a/detection_rules/action.py
+++ b/detection_rules/action.py
@@ -1,0 +1,62 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+"""Dataclasses for Action."""
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from .mixins import MarshmallowDataclassMixin
+from .schemas import definitions
+
+
+@dataclass(frozen=True)
+class ActionMeta(MarshmallowDataclassMixin):
+    """Data stored in an exception's [metadata] section of TOML."""
+    creation_date: definitions.Date
+    rule_id: definitions.UUIDString
+    rule_name: str
+    updated_date: definitions.Date
+
+    # Optional fields
+    deprecation_date: Optional[definitions.Date]
+    comments: Optional[str]
+    maturity: Optional[definitions.Maturity]
+
+
+@dataclass
+class Action(MarshmallowDataclassMixin):
+    """Data object for rule Action."""
+    @dataclass
+    class ActionParams:
+        body: str
+
+    action_type_id: str
+    group: str
+    params: ActionParams
+    id: Optional[str]
+    frequency: Optional[dict]
+
+
+@dataclass(frozen=True)
+class TOMLActionContents(MarshmallowDataclassMixin):
+    """Object for action from TOML file."""
+    metadata: ActionMeta
+    actions: List[Action]
+
+
+@dataclass(frozen=True)
+class TOMLAction:
+    """Object for action from TOML file."""
+    contents: TOMLActionContents
+    path: Path
+
+    @property
+    def name(self):
+        return self.contents.metadata.rule_name
+
+    @property
+    def id(self):
+        return self.contents.metadata.rule_id

--- a/detection_rules/etc/_config.yaml
+++ b/detection_rules/etc/_config.yaml
@@ -5,6 +5,9 @@ files:
   packages: packages.yml
   stack_schema_map: stack-schema-map.yaml
   version_lock: version.lock.json
+# directories:
+  # actions_dir: exceptions
+  # exceptions_dir: actions
 
 # to set up a custom rules directory, copy this file to the root of the custom rules directory, which is set
 #   using the environment variable DETECTION_RULES_DIR
@@ -18,6 +21,12 @@ files:
 #         ├── packages.yml
 #         ├── stack-schema-map.yaml
 #         └── version.lock.json
+#     └── actions
+##         ├── action_1.toml
+##         ├── action_2.toml
+#     └── exceptions
+##         ├── exception_1.toml
+##         ├── exception_2.toml
 #
 #   update custom-rules/_config.yaml with:
 #     deprecated_rules: etc/deprecated_rules.json

--- a/detection_rules/etc/_config.yaml
+++ b/detection_rules/etc/_config.yaml
@@ -6,7 +6,6 @@ files:
   stack_schema_map: stack-schema-map.yaml
   version_lock: version.lock.json
 
-
 # to set up a custom rules directory, copy this file to the root of the custom rules directory, which is set
 #   using the environment variable DETECTION_RULES_DIR
 #   example structure:
@@ -32,4 +31,12 @@ files:
 #
 
 # testing:
-#  TBD...
+#   config: etc/example_test_config.yaml
+
+# This points to the testing config file (see example under detection_rules/etc/example_test_config.yaml)
+# This can either be set here or as the environment variable `DETECTION_RULES_TEST_CONFIG`, with precedence
+#   going to the environment variable if both are set. Having both these options allows for configuring testing on
+#   prebuilt Elastic rules without specifying a rules _config.yaml.
+#
+# If set in this file, the path should be relative to the location of this config. If passed as an environment variable,
+#    it should be the full path

--- a/detection_rules/etc/example_test_config.yaml
+++ b/detection_rules/etc/example_test_config.yaml
@@ -1,0 +1,39 @@
+
+# set the environment variable DETECTION_RULES_TEST_CONFIG
+
+# `bypass` and `test_only` are mutually exclusive and will cause an error if both are specified.
+#
+# tests can be defined by their full name or using glob-style patterns with the following notation
+#   pattern:*rule*
+#   the patterns are case sensitive
+
+unit_tests:
+  # define tests to explicitly bypass, with all others being run
+  #
+  # to run all tests, set bypass to empty or leave this file commented out
+  bypass:
+#  - tests.test_all_rules.TestRuleMetadata.test_event_dataset
+#  - tests.test_all_rules.TestRuleMetadata.test_integration_tag
+#  - tests.test_gh_workflows.TestWorkflows.test_matrix_to_lock_version_defaults
+#  - pattern:*rule*
+#  - pattern:*kuery*
+
+  # define tests to explicitly run, with all others being bypassed
+  #
+  # to bypass all tests, set test_only to empty
+  test_only:
+#  - tests.test_all_rules.TestRuleMetadata.test_event_dataset
+#  - pattern:*rule*
+
+
+# `bypass` and `test_only` are mutually exclusive and will cause an error if both are specified.
+#
+# both variables require a list of rule_ids
+rule_validation:
+
+  bypass:
+#    - "34fde489-94b0-4500-a76f-b8a157cf9269"
+
+
+  test_only:
+#    - "34fde489-94b0-4500-a76f-b8a157cf9269"

--- a/detection_rules/exception.py
+++ b/detection_rules/exception.py
@@ -1,0 +1,143 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+"""Rule exceptions data."""
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Literal, Optional, Union
+
+from marshmallow import validates_schema, ValidationError
+
+from .mixins import MarshmallowDataclassMixin
+from .schemas import definitions
+
+
+# https://www.elastic.co/guide/en/security/current/exceptions-api-overview.html
+
+@dataclass(frozen=True)
+class ExceptionMeta(MarshmallowDataclassMixin):
+    """Data stored in an exception's [metadata] section of TOML."""
+    creation_date: definitions.Date
+    rule_id: definitions.UUIDString
+    rule_name: str
+    updated_date: definitions.Date
+
+    # Optional fields
+    deprecation_date: Optional[definitions.Date]
+    comments: Optional[str]
+    maturity: Optional[definitions.Maturity]
+
+
+@dataclass(frozen=True)
+class BaseExceptionItemEntry(MarshmallowDataclassMixin):
+    field: str
+    type: definitions.ExceptionEntryType
+
+
+@dataclass(frozen=True)
+class NestedExceptionItemEntry(BaseExceptionItemEntry, MarshmallowDataclassMixin):
+    entries: List['ExceptionItemEntry']
+
+    @validates_schema
+    def validate_nested_entry(self, data: dict, **kwargs):
+        if data.get('list') is not None:
+            raise ValidationError('Nested entries cannot define a list')
+
+
+@dataclass(frozen=True)
+class ExceptionItemEntry(BaseExceptionItemEntry, MarshmallowDataclassMixin):
+    @dataclass(frozen=True)
+    class ListObject:
+        id: definitions.UUIDString
+        type: definitions.EsDataTypes
+
+    list: Optional[ListObject]
+    operator: definitions.ExceptionEntryOperator
+    value: Optional[Union[str, List[str]]]
+
+    @validates_schema
+    def validate_entry(self, data: dict, **kwargs):
+        value = data.get('value', '')
+        if data['type'] in ('exists', 'list') and value is not None:
+            raise ValidationError(f'Entry of type {data["type"]} cannot have a value')
+        elif data['type'] in ('match', 'wildcard') and not isinstance(value, str):
+            raise ValidationError(f'Entry of type {data["type"]} must have a string value')
+        elif data['type'] == 'match_any' and not isinstance(value, list):
+            raise ValidationError(f'Entry of type {data["type"]} must have a list of strings as a value')
+
+
+@dataclass(frozen=True)
+class ExceptionItem(MarshmallowDataclassMixin):
+    @dataclass(frozen=True)
+    class Comment:
+        comment: str
+
+    comments: List[Optional[Comment]]
+    description: str
+    entries: List[Union[ExceptionItemEntry, NestedExceptionItemEntry]]
+    list_id: str
+    item_id: Optional[str]  # api sets field when not provided
+    meta: Optional[dict]
+    name: str
+    namespace_type: Optional[definitions.ExceptionNamespaceType]  # defaults to "single" if not provided
+    tags: Optional[List[str]]
+    type: Literal['simple']
+
+
+@dataclass(frozen=True)
+class EndpointException(ExceptionItem, MarshmallowDataclassMixin):
+    _tags: List[definitions.ExceptionItemEndpointTags]
+
+    @validates_schema
+    def validate_endpoint(self, data: dict, **kwargs):
+        for entry in data['entries']:
+            if entry['operator'] == "excluded":
+                raise ValidationError("Endpoint exceptions cannot have an `excluded` operator")
+
+
+@dataclass(frozen=True)
+class DetectionException(ExceptionItem, MarshmallowDataclassMixin):
+    expire_time: Optional[str]  # fields.DateTime]  # maybe this is isoformat?
+
+
+@dataclass(frozen=True)
+class ExceptionContainer(MarshmallowDataclassMixin):
+    description: str
+    list_id: Optional[str]
+    meta: Optional[dict]
+    name: str
+    namespace_type: Optional[definitions.ExceptionNamespaceType]
+    tags: Optional[List[str]]
+    type: definitions.ExceptionContainerType
+
+    def to_rule_entry(self) -> dict:
+        """Returns a dict of the format required in rule.exception_list."""
+        # requires KSO id to be consider valid structure
+        return dict(namespace_type=self.namespace_type, type=self.type, list_id=self.list_id)
+
+
+@dataclass(frozen=True)
+class Data(MarshmallowDataclassMixin):
+    container: ExceptionContainer
+    items: List[DetectionException]  # Union[DetectionException, EndpointException]]
+
+
+@dataclass(frozen=True)
+class TOMLExceptionContents(MarshmallowDataclassMixin):
+    metadata: ExceptionMeta
+    exceptions: List[Data]
+
+
+@dataclass(frozen=True)
+class TOMLException:
+    contents: TOMLExceptionContents
+    path: Optional[Path] = None
+
+    @property
+    def name(self):
+        return self.contents.metadata.rule_name
+
+    @property
+    def id(self):
+        return self.contents.metadata.rule_id

--- a/detection_rules/generic_loader.py
+++ b/detection_rules/generic_loader.py
@@ -1,0 +1,176 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+"""Load generic toml formatted files for exceptions and actions."""
+import io
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional, Union
+
+import pytoml
+
+from .action import TOMLAction, TOMLActionContents
+from .exception import TOMLException, TOMLExceptionContents
+from .misc import parse_rules_config
+from .rule_loader import dict_filter
+from .schemas import definitions
+
+
+RULES_CONFIG = parse_rules_config()
+
+GenericCollectionTypes = Union[TOMLAction, TOMLException]
+GenericCollectionContentTypes = Union[TOMLActionContents, TOMLExceptionContents]
+
+
+def metadata_filter(**metadata) -> Callable[[GenericCollectionTypes], bool]:
+    """Get a filter callback based off item metadata"""
+    flt = dict_filter(metadata)
+
+    def callback(item: GenericCollectionTypes) -> bool:
+        target_dict = item.contents.metadata.to_dict()
+        return flt(target_dict)
+
+    return callback
+
+
+class GenericCollection:
+    """Generic collection for action and exception objects."""
+
+    items: list
+    __default = None
+
+    def __init__(self, items: Optional[List[GenericCollectionTypes]] = None):
+        self.id_map: Dict[definitions.UUIDString, GenericCollectionTypes] = {}
+        self.file_map: Dict[Path, GenericCollectionTypes] = {}
+        self.name_map: Dict[definitions.RuleName, GenericCollectionTypes] = {}
+        self.items: List[GenericCollectionTypes] = []
+        self.errors: Dict[Path, Exception] = {}
+        self.frozen = False
+
+        self._toml_load_cache: Dict[Path, dict] = {}
+
+        for items in (items or []):
+            self.add_item(items)
+
+    def __len__(self):
+        """Get the total amount of exceptions in the collection."""
+        return len(self.items)
+
+    def __iter__(self):
+        """Iterate over all items in the collection."""
+        return iter(self.items)
+
+    def __contains__(self, item: GenericCollectionTypes):
+        """Check if an item is in the map by comparing IDs."""
+        return item.id in self.id_map
+
+    def filter(self, cb: Callable[[TOMLException], bool]) -> 'GenericCollection':
+        """Retrieve a filtered collection of items."""
+        filtered_collection = GenericCollection()
+
+        for item in filter(cb, self.items):
+            filtered_collection.add_item(item)
+
+        return filtered_collection
+
+    @staticmethod
+    def deserialize_toml_string(contents: Union[bytes, str]) -> dict:
+        return pytoml.loads(contents)
+
+    def _load_toml_file(self, path: Path) -> dict:
+        if path in self._toml_load_cache:
+            return self._toml_load_cache[path]
+
+        # use pytoml instead of toml because of annoying bugs
+        # https://github.com/uiri/toml/issues/152
+        # might also be worth looking at https://github.com/sdispater/tomlkit
+        with io.open(path, "r", encoding="utf-8") as f:
+            toml_dict = self.deserialize_toml_string(f.read())
+            self._toml_load_cache[path] = toml_dict
+            return toml_dict
+
+    def _get_paths(self, directory: Path, recursive=True) -> List[Path]:
+        return sorted(directory.rglob('*.toml') if recursive else directory.glob('*.toml'))
+
+    def _assert_new(self, item: GenericCollectionTypes):
+        id_map = self.id_map
+        file_map = self.file_map
+        name_map = self.name_map
+
+        assert not self.frozen, f"Unable to add item {item.name} {item.id} to a frozen collection"
+        assert item.id not in id_map, \
+            f"Rule ID {item.id} for {item.name} collides with rule {id_map.get(item.id).name}"
+        assert item.name not in name_map, \
+            f"Rule Name {item.name} for {item.id} collides with rule ID {name_map.get(item.name).id}"
+
+        if item.path is not None:
+            item_path = item.path.resolve()
+            assert item_path not in file_map, f"Item file {item_path} already loaded"
+            file_map[item_path] = item
+
+    def add_item(self, item: GenericCollectionTypes):
+        self._assert_new(item)
+        self.id_map[item.id] = item
+        self.name_map[item.name] = item
+        self.items.append(item)
+
+    def load_dict(self, obj: dict, path: Optional[Path] = None) -> GenericCollectionTypes:
+        is_exception = True if 'exceptions' in obj else False
+        contents = TOMLExceptionContents.from_dict(obj) if is_exception else TOMLActionContents.from_dict(obj)
+        item = TOMLException(path=path, contents=contents)
+        self.add_item(item)
+        return item
+
+    def load_file(self, path: Path) -> GenericCollectionTypes:
+        try:
+            path = path.resolve()
+
+            # use the default generic loader as a cache.
+            # if it already loaded the item, then we can just use it from that
+            if self.__default is not None and self is not self.__default:
+                if path in self.__default.file_map:
+                    item = self.__default.file_map[path]
+                    self.add_item(item)
+                    return item
+
+            obj = self._load_toml_file(path)
+            return self.load_dict(obj, path=path)
+        except Exception:
+            print(f"Error loading item in {path}")
+            raise
+
+    def load_files(self, paths: Iterable[Path]):
+        """Load multiple files into the collection."""
+        for path in paths:
+            self.load_file(path)
+
+    def load_directory(self, directory: Path, recursive=True, toml_filter: Optional[Callable[[dict], bool]] = None):
+        paths = self._get_paths(directory, recursive=recursive)
+        if toml_filter is not None:
+            paths = [path for path in paths if toml_filter(self._load_toml_file(path))]
+
+        self.load_files(paths)
+
+    def load_directories(self, directories: Iterable[Path], recursive=True,
+                         toml_filter: Optional[Callable[[dict], bool]] = None):
+        for path in directories:
+            self.load_directory(path, recursive=recursive, toml_filter=toml_filter)
+
+    def freeze(self):
+        """Freeze the generic collection and make it immutable going forward."""
+        self.frozen = True
+
+    @classmethod
+    def default(cls) -> 'GenericCollection':
+        """Return the default item collection, which retrieves from default config location."""
+        if cls.__default is None:
+            collection = GenericCollection()
+            if RULES_CONFIG.exception_dir:
+                collection.load_directory(RULES_CONFIG.exception_dir)
+            if RULES_CONFIG.action_dir:
+                collection.load_directory(RULES_CONFIG.action_dir)
+            collection.freeze()
+            cls.__default = collection
+
+        return cls.__default

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -33,7 +33,9 @@ from .rule_loader import RuleCollection
 from .schemas import all_versions, definitions, get_incompatible_fields, get_schema_file
 from .utils import Ndjson, get_path, get_etc_path, clear_caches, load_dump, load_rule_contents
 
+
 RULES_DIR = get_path('rules')
+ROOT_DIR = Path(RULES_DIR).parent
 RULES_CONFIG = parse_rules_config()
 
 
@@ -415,8 +417,16 @@ def test_rules(ctx):
     """Run unit tests over all of the rules."""
     import pytest
 
+    rules_config = ctx.obj['rules_config']
+    test_config = rules_config.test_config
+    tests, skipped = test_config.get_test_names(formatted=True)
+
+    if skipped:
+        click.echo(f'Tests skipped per config ({len(skipped)}):')
+        click.echo('\n'.join(skipped))
+
     clear_caches()
-    ctx.exit(pytest.main(["-v"]))
+    ctx.exit(pytest.main(['-v'] + tests))
 
 
 @root.group('typosquat')

--- a/detection_rules/misc.py
+++ b/detection_rules/misc.py
@@ -433,6 +433,9 @@ class RulesConfig:
     version_lock: Dict[str, dict]
     test_config: TestConfig
 
+    action_dir: Optional[Path] = None
+    exception_dir: Optional[Path] = None
+
 
 @cached
 def parse_rules_config(path: Optional[Path] = None) -> RulesConfig:
@@ -471,6 +474,10 @@ def parse_rules_config(path: Optional[Path] = None) -> RulesConfig:
     files = {f'{k}_file': base_dir.joinpath(v) for k, v in loaded['files'].items()}
     contents = {k: load_dump(str(base_dir.joinpath(v))) for k, v in loaded['files'].items()}
     contents.update(**files)
+
+    if loaded.get('directories'):
+        contents.update({k: base_dir.joinpath(v) for k, v in loaded['directories'].items()})
+
     rules_config = RulesConfig(test_config=test_config, **contents)
     return rules_config
 

--- a/detection_rules/misc.py
+++ b/detection_rules/misc.py
@@ -4,14 +4,16 @@
 # 2.0.
 
 """Misc support."""
+import fnmatch
 import os
 import re
 import time
+import unittest
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from functools import wraps
-from typing import Dict, NoReturn, Optional
+from functools import cached_property, wraps
+from typing import Dict, List, NoReturn, Optional
 
 import click
 import requests
@@ -52,6 +54,7 @@ JS_LICENSE = """
 """.strip().format("\n".join(' * ' + line for line in LICENSE_LINES))
 
 
+ROOT_DIR = Path(__file__).parent.parent
 CUSTOM_RULES_DIR = os.getenv('CUSTOM_RULES_DIR', None)
 
 
@@ -115,8 +118,8 @@ def nest_from_dot(dots, value):
 
     nested = {fields.pop(): value}
 
-    for field in reversed(fields):
-        nested = {field: nested}
+    for field_ in reversed(fields):
+        nested = {field_: nested}
 
     return nested
 
@@ -296,6 +299,127 @@ def parse_user_config():
     return config
 
 
+def discover_tests(start_dir: str = 'tests', pattern: str = 'test*.py', top_level_dir: Optional[str] = None):
+    def list_tests(s, tests=None):
+        if tests is None:
+            tests = []
+        for test in s:
+            if isinstance(test, unittest.TestSuite):
+                list_tests(test, tests)
+            else:
+                tests.append(test.id())
+        return tests
+
+    loader = unittest.defaultTestLoader
+    suite = loader.discover(start_dir, pattern=pattern, top_level_dir=top_level_dir or str(ROOT_DIR))
+    return list_tests(suite)
+
+
+@dataclass
+class UnitTest:
+    bypass: Optional[List[str]] = None
+    test_only: Optional[List[str]] = None
+
+    def __post_init__(self):
+        assert not (self.bypass and self.test_only), 'Cannot use both test_only and bypass'
+
+
+@dataclass
+class RuleValidation:
+    bypass: Optional[List[str]] = None
+    test_only: Optional[List[str]] = None
+
+    def __post_init__(self):
+        assert not (self.bypass and self.test_only), 'Cannot use both test_only and bypass'
+
+
+@dataclass
+class TestConfig:
+    """Detection rules test config file"""
+
+    @classmethod
+    def from_dict(cls, test_file: Optional[Path] = None, unit_tests: Optional[dict] = None,
+                  rule_validation: Optional[dict] = None):
+        return cls(test_file=test_file or None, unit_tests=UnitTest(**unit_tests or {}),
+                   rule_validation=RuleValidation(**rule_validation or {}))
+
+    test_file: Optional[Path] = None
+    unit_tests: Optional[UnitTest] = None
+    rule_validation: Optional[RuleValidation] = None
+
+    @cached_property
+    def all_tests(self):
+        """Get the list of all test names."""
+        return discover_tests()
+
+    def tests_by_patterns(self, *patterns: str) -> List[str]:
+        """Get the list of test names by patterns."""
+        tests = set()
+        for pattern in patterns:
+            tests.update(list(fnmatch.filter(self.all_tests, pattern)))
+        return sorted(tests)
+
+    @staticmethod
+    def parse_out_patterns(names: List[str]) -> (List[str], List[str]):
+        """Parse out test patterns from a list of test names."""
+        patterns = []
+        tests = []
+        for name in names:
+            if name.startswith('pattern:') and '*' in name:
+                patterns.append(name[len('pattern:'):])
+            else:
+                tests.append(name)
+        return patterns, tests
+
+    def get_test_names(self, formatted: bool = False) -> (List[str], List[str]):
+        """Get the list of test names to run."""
+        patterns_t, tests_t = self.parse_out_patterns(self.unit_tests.test_only or [])
+        patterns_b, tests_b = self.parse_out_patterns(self.unit_tests.bypass or [])
+        tests = tests_t + tests_b
+        patterns = patterns_t + patterns_b
+        unknowns = sorted(set(tests) - set(self.all_tests))
+        assert not unknowns, f'Unrecognized test names in config ({self.test_file}): {unknowns}'
+
+        combined_tests = sorted(set(tests + self.tests_by_patterns(*patterns)))
+
+        if self.unit_tests.test_only:
+            tests = combined_tests
+            skipped = [t for t in self.all_tests if t not in tests]
+        elif self.unit_tests.bypass:
+            tests = []
+            skipped = []
+            for test in self.all_tests:
+                if test not in combined_tests:
+                    tests.append(test)
+                else:
+                    skipped.append(test)
+        else:
+            tests = self.all_tests
+            skipped = []
+
+        if formatted:
+            def fmt_tests(lt) -> List[str]:
+                raw = [t.rsplit('.', maxsplit=2) for t in lt]
+                ft = []
+                for test in raw:
+                    path, clazz, method = test
+                    path = f'{path.replace(".", os.path.sep)}.py'
+                    ft.append('::'.join([path, clazz, method]))
+                return ft
+
+            return fmt_tests(tests), fmt_tests(skipped)
+        else:
+            return tests, skipped
+
+    def check_skip_by_rule_id(self, rule_id: str) -> bool:
+        """Check if a rule_id should be skipped."""
+        bypass = self.rule_validation.bypass
+        test_only = self.rule_validation.test_only
+        if not (bypass or test_only):
+            return False
+        return (bypass and rule_id in bypass) or (test_only and rule_id not in test_only)
+
+
 @dataclass
 class RulesConfig:
     """Detection rules config file."""
@@ -307,6 +431,7 @@ class RulesConfig:
     stack_schema_map: Dict[str, dict]
     version_lock_file: Path
     version_lock: Dict[str, dict]
+    test_config: TestConfig
 
 
 @cached
@@ -314,20 +439,39 @@ def parse_rules_config(path: Optional[Path] = None) -> RulesConfig:
     """Parse the _config.yaml file for default or custom rules."""
     if path:
         assert path.exists(), f'rules config file does not exist: {path}'
-        loaded = yaml.safe_load(path.read_text())['files']
+        loaded = yaml.safe_load(path.read_text())
     elif CUSTOM_RULES_DIR:
         path = Path(CUSTOM_RULES_DIR) / '_config.yaml'
         assert path.exists(), f'_config.yaml file missing in {CUSTOM_RULES_DIR}'
-        loaded = yaml.safe_load(path.read_text())['files']
+        loaded = yaml.safe_load(path.read_text())
     else:
         path = Path(get_etc_path('_config.yaml'))
-        loaded = load_etc_dump('_config.yaml')['files']
+        loaded = load_etc_dump('_config.yaml')
 
     base_dir = path.resolve().parent
-    files = {f'{k}_file': base_dir.joinpath(v) for k, v in loaded.items()}
-    contents = {k: load_dump(str(base_dir.joinpath(v))) for k, v in loaded.items()}
+
+    # precedence to the environment variable
+    # environment variable is absolute path and config file is relative to the _config.yaml file
+    test_config_ev = os.getenv('DETECTION_RULES_TEST_CONFIG', None)
+    if test_config_ev:
+        test_config_path = Path(test_config_ev)
+    else:
+        test_config_file = loaded.get('testing', {}).get('config')
+        if test_config_file:
+            test_config_path = base_dir.joinpath(test_config_file)
+        else:
+            test_config_path = None
+
+    if test_config_path:
+        test_config_data = yaml.safe_load(test_config_path.read_text())
+        test_config = TestConfig.from_dict(test_file=test_config_path, **test_config_data)
+    else:
+        test_config = TestConfig.from_dict()
+
+    files = {f'{k}_file': base_dir.joinpath(v) for k, v in loaded['files'].items()}
+    contents = {k: load_dump(str(base_dir.joinpath(v))) for k, v in loaded['files'].items()}
     contents.update(**files)
-    rules_config = RulesConfig(**contents)
+    rules_config = RulesConfig(test_config=test_config, **contents)
     return rules_config
 
 

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -138,6 +138,11 @@ CardinalityFields = NewType('CardinalityFields', List[NonEmptyStr], validate=val
 CodeString = NewType("CodeString", str)
 ConditionSemVer = NewType('ConditionSemVer', str, validate=validate.Regexp(CONDITION_VERSION_PATTERN))
 Date = NewType('Date', str, validate=validate.Regexp(DATE_PATTERN))
+ExceptionEntryOperator = Literal['included', 'excluded']
+ExceptionEntryType = Literal['match', 'match_any', 'exists', 'list', 'wildcard', 'nested']
+ExceptionNamespaceType = Literal['single', 'agnostic']
+ExceptionItemEndpointTags = Literal['endpoint', 'os:windows', 'os:linux', 'os:macos']
+ExceptionContainerType = Literal['detection', 'endpoint', 'rule_default']
 FilterLanguages = Literal["eql", "esql", "kuery", "lucene"]
 Interval = NewType('Interval', str, validate=validate.Regexp(INTERVAL_PATTERN))
 InvestigateProviderQueryType = Literal["phrase", "range"]
@@ -170,3 +175,18 @@ BuildingBlockType = Literal['default']
 MachineLearningType = getattr(Literal, '__getitem__')(tuple(MACHINE_LEARNING_PACKAGES))  # noqa: E999
 MachineLearningTypeLower = getattr(Literal, '__getitem__')(
     tuple(map(str.lower, MACHINE_LEARNING_PACKAGES)))  # noqa: E999
+##
+
+EsDataTypes = Literal[
+    'binary', 'boolean',
+    'keyword', 'constant_keyword', 'wildcard',
+    'long', 'integer', 'short', 'byte', 'double', 'float', 'half_float', 'scaled_float', 'unsigned_long',
+    'date', 'date_nanos',
+    'alias', 'object', 'flatten', 'nested', 'join',
+    'integer_range', 'float_range', 'long_range', 'double_range', 'date_range', 'ip_range',
+    'ip', 'version', 'murmur3', 'aggregate_metric_double', 'histogram',
+    'text', 'text_match_only', 'annotated-text', 'completion', 'search_as_you_type', 'token_count',
+    'dense_vector', 'sparse_vector', 'rank_feature', 'rank_features',
+    'geo_point', 'geo_shape', 'point', 'shape',
+    'percolator'
+]


### PR DESCRIPTION
Updates for configurable tests. This is just to show the delta since this targets my custom directory support PR.

## Summary

This makes unit tests configurable by name and pattern and rule validation by rule_id, configurable by a `test_config,yaml` file.

## Details

The test file is exposed either by setting `DETECTION_RULES_TEST_CONFIG` to the path, or by referencing it from within the `_config.yaml`. The enivronment variable allow bypassing tests on prebuilt rules where modifying the built-in `_config.yaml` is not feasible due to VCS.


### Opting in/out of tests

```
# `bypass` and `test_only` are mutually exclusive and will cause an error if both are specified.
#
# tests can be defined by their full name or using glob-style patterns with the following notation
#   pattern:*rule*
#   the patterns are case sensitive

unit_tests:
  # define tests to explicitly bypass, with all others being run
  #
  # to run all tests, set bypass to empty or leave this file commented out
  bypass:
#  - tests.test_all_rules.TestRuleMetadata.test_event_dataset
#  - tests.test_all_rules.TestRuleMetadata.test_integration_tag
#  - tests.test_gh_workflows.TestWorkflows.test_matrix_to_lock_version_defaults
#  - pattern:*rule*
#  - pattern:*kuery*

  # define tests to explicitly run, with all others being bypassed
  #
  # to bypass all tests, set test_only to empty
  test_only:
#  - tests.test_all_rules.TestRuleMetadata.test_event_dataset
#  - pattern:*rule*
```

### Opting out of rule validation

```
# `bypass` and `test_only` are mutually exclusive and will cause an error if both are specified.
#
# both variables require a list of rule_ids
rule_validation:

  bypass:
#    - "34fde489-94b0-4500-a76f-b8a157cf9269"


  test_only:
#    - "34fde489-94b0-4500-a76f-b8a157cf9269"
```

### Testing

Sample config:

```yaml
unit_tests:
  test_only:
    - pattern:*rules*
   # bypass:

rule_validation:
  test_only:
  - "34fde489-94b0-4500-a76f-b8a157cf9269"
   # bypass:

```

#### 1. `make test` (or `python -m detection_rules test`)

- this tests the defaults, which opts in to all unit tests and validation


#### 2. `DETECTION_RULES_TEST_CONFIG=path/to/test_config.yaml make test`

- this tests built in rules against a config (optionally play with config parameters to opt in and out)

<details>

```
Tests skipped per config (89):
tests/kuery/test_dsl.py::TestKQLtoDSL::test_and_query
tests/kuery/test_dsl.py::TestKQLtoDSL::test_field_exists
tests/kuery/test_dsl.py::TestKQLtoDSL::test_field_inequality
tests/kuery/test_dsl.py::TestKQLtoDSL::test_field_match
tests/kuery/test_dsl.py::TestKQLtoDSL::test_not_query
tests/kuery/test_dsl.py::TestKQLtoDSL::test_optimizations
tests/kuery/test_dsl.py::TestKQLtoDSL::test_or_query
tests/kuery/test_eql2kql.py::TestEql2Kql::test_and_query
tests/kuery/test_eql2kql.py::TestEql2Kql::test_boolean_precedence
tests/kuery/test_eql2kql.py::TestEql2Kql::test_field_equals
tests/kuery/test_eql2kql.py::TestEql2Kql::test_field_inequality
tests/kuery/test_eql2kql.py::TestEql2Kql::test_ip_checks
tests/kuery/test_eql2kql.py::TestEql2Kql::test_list_of_values
tests/kuery/test_eql2kql.py::TestEql2Kql::test_not_query
tests/kuery/test_eql2kql.py::TestEql2Kql::test_or_query
tests/kuery/test_eql2kql.py::TestEql2Kql::test_wildcard_field
tests/kuery/test_evaluator.py::EvaluatorTests::test_and_expr
tests/kuery/test_evaluator.py::EvaluatorTests::test_and_values
tests/kuery/test_evaluator.py::EvaluatorTests::test_cidr_match
tests/kuery/test_evaluator.py::EvaluatorTests::test_field_exists
tests/kuery/test_evaluator.py::EvaluatorTests::test_flattening
tests/kuery/test_evaluator.py::EvaluatorTests::test_list_value
tests/kuery/test_evaluator.py::EvaluatorTests::test_not_value
tests/kuery/test_evaluator.py::EvaluatorTests::test_or_expr
tests/kuery/test_evaluator.py::EvaluatorTests::test_or_values
tests/kuery/test_evaluator.py::EvaluatorTests::test_quoted_wildcard
tests/kuery/test_evaluator.py::EvaluatorTests::test_range
tests/kuery/test_evaluator.py::EvaluatorTests::test_single_value
tests/kuery/test_evaluator.py::EvaluatorTests::test_wildcard
tests/kuery/test_kql2eql.py::TestKql2Eql::test_and_query
tests/kuery/test_kql2eql.py::TestKql2Eql::test_boolean_precedence
tests/kuery/test_kql2eql.py::TestKql2Eql::test_field_equals
tests/kuery/test_kql2eql.py::TestKql2Eql::test_field_inequality
tests/kuery/test_kql2eql.py::TestKql2Eql::test_list_of_values
tests/kuery/test_kql2eql.py::TestKql2Eql::test_lone_value
tests/kuery/test_kql2eql.py::TestKql2Eql::test_nested_query
tests/kuery/test_kql2eql.py::TestKql2Eql::test_not_query
tests/kuery/test_kql2eql.py::TestKql2Eql::test_or_query
tests/kuery/test_kql2eql.py::TestKql2Eql::test_schema
tests/kuery/test_lint.py::LintTests::test_and_not
tests/kuery/test_lint.py::LintTests::test_compound
tests/kuery/test_lint.py::LintTests::test_double_negate
tests/kuery/test_lint.py::LintTests::test_extract_not
tests/kuery/test_lint.py::LintTests::test_ip
tests/kuery/test_lint.py::LintTests::test_lint_field
tests/kuery/test_lint.py::LintTests::test_lint_precedence
tests/kuery/test_lint.py::LintTests::test_merge_fields
tests/kuery/test_lint.py::LintTests::test_mixed_demorgans
tests/kuery/test_lint.py::LintTests::test_not_demorgans
tests/kuery/test_lint.py::LintTests::test_not_or
tests/kuery/test_lint.py::LintTests::test_upper_tokens
tests/kuery/test_parser.py::ParserTests::test_conversion
tests/kuery/test_parser.py::ParserTests::test_date
tests/kuery/test_parser.py::ParserTests::test_keyword
tests/kuery/test_parser.py::ParserTests::test_list_equals
tests/kuery/test_parser.py::ParserTests::test_multiple_types_fail
tests/kuery/test_parser.py::ParserTests::test_multiple_types_success
tests/kuery/test_parser.py::ParserTests::test_number_exists
tests/kuery/test_parser.py::ParserTests::test_number_wildcard_fail
tests/kuery/test_parser.py::ParserTests::test_type_family_fail
tests/kuery/test_parser.py::ParserTests::test_type_family_success
tests/test_gh_workflows.py::TestWorkflows::test_matrix_to_lock_version_defaults
tests/test_mappings.py::TestMappings::test_false_positives
tests/test_mappings.py::TestMappings::test_true_positives
tests/test_packages.py::TestPackages::test_package_loader_default_configs
tests/test_packages.py::TestPackages::test_package_loader_production_config
tests/test_packages.py::TestPackages::test_package_summary
tests/test_packages.py::TestPackages::test_rule_versioning
tests/test_packages.py::TestRegistryPackage::test_registry_package_config
tests/test_schemas.py::TestSchemas::test_eql_validation
tests/test_schemas.py::TestSchemas::test_query_downgrade_7_x
tests/test_schemas.py::TestSchemas::test_query_downgrade_8_x
tests/test_schemas.py::TestSchemas::test_threshold_downgrade_7_x
tests/test_schemas.py::TestSchemas::test_threshold_downgrade_8_x
tests/test_schemas.py::TestSchemas::test_versioned_downgrade_7_x
tests/test_schemas.py::TestSchemas::test_versioned_downgrade_8_x
tests/test_schemas.py::TestVersionLockSchema::test_version_lock_has_nested_previous
tests/test_schemas.py::TestVersionLockSchema::test_version_lock_no_previous
tests/test_schemas.py::TestVersions::test_stack_schema_map
tests/test_toml_formatter.py::TestRuleTomlFormatter::test_formatter_deep
tests/test_toml_formatter.py::TestRuleTomlFormatter::test_formatter_rule
tests/test_toml_formatter.py::TestRuleTomlFormatter::test_normalization
tests/test_transform_fields.py::TestGuideMarkdownPlugins::test_plugin_conversion
tests/test_transform_fields.py::TestGuideMarkdownPlugins::test_transform_guide_markdown_plugins
tests/test_utils.py::TestTimeUtils::test_caching
tests/test_utils.py::TestTimeUtils::test_event_class_normalization
tests/test_utils.py::TestTimeUtils::test_schema_multifields
tests/test_utils.py::TestTimeUtils::test_time_normalize
tests/test_version_locking.py::TestVersionLock::test_previous_entries_gte_current_min_stack
========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.8.4, pytest-7.2.2, pluggy-1.0.0 -- /Users/jibarra/PycharmProjects/detection-rules-fork/env/detection-rules-build/bin/python
cachedir: .pytest_cache
rootdir: /Users/jibarra/PycharmProjects/detection-rules-fork, configfile: pyproject.toml
plugins: typeguard-2.13.3
collected 52 items                                                                                                                                                                                       

tests/test_all_rules.py::TestAlertSuppression::test_group_field_in_schemas FAILED                                                                                                                  [  1%]
tests/test_all_rules.py::TestAlertSuppression::test_group_length SKIPPED (Rule loader failure)                                                                                                     [  3%]
tests/test_all_rules.py::TestBuildTimeFields::test_build_fields_min_stack SKIPPED (Rule loader failure)                                                                                            [  5%]
tests/test_all_rules.py::TestIncompatibleFields::test_rule_backports_for_restricted_fields SKIPPED (Rule loader failure)                                                                           [  7%]
tests/test_all_rules.py::TestIntegrationRules::test_all_min_stack_rules_have_comment SKIPPED (Rule loader failure)                                                                                 [  9%]
tests/test_all_rules.py::TestIntegrationRules::test_integration_guide SKIPPED (8.3+ Stacks Have Related Integrations Feature)                                                                      [ 11%]
tests/test_all_rules.py::TestIntegrationRules::test_ml_integration_jobs_exist SKIPPED (Rule loader failure)                                                                                        [ 13%]
tests/test_all_rules.py::TestIntegrationRules::test_rule_demotions SKIPPED (Rule loader failure)                                                                                                   [ 15%]
tests/test_all_rules.py::TestLicense::test_elastic_license_only_v2 SKIPPED (Rule loader failure)                                                                                                   [ 17%]
tests/test_all_rules.py::TestNoteMarkdownPlugins::test_if_plugins_explicitly_defined SKIPPED (Rule loader failure)                                                                                 [ 19%]
tests/test_all_rules.py::TestNoteMarkdownPlugins::test_note_has_osquery_warning SKIPPED (Rule loader failure)                                                                                      [ 21%]
tests/test_all_rules.py::TestNoteMarkdownPlugins::test_plugin_placeholders_match_entries SKIPPED (Rule loader failure)                                                                             [ 23%]
tests/test_all_rules.py::TestRiskScoreMismatch::test_rule_risk_score_severity_mismatch SKIPPED (Rule loader failure)                                                                               [ 25%]
tests/test_all_rules.py::TestRuleFiles::test_bbr_in_correct_dir SKIPPED (Rule loader failure)                                                                                                      [ 26%]
tests/test_all_rules.py::TestRuleFiles::test_non_bbr_in_correct_dir SKIPPED (Rule loader failure)                                                                                                  [ 28%]
tests/test_all_rules.py::TestRuleFiles::test_rule_file_name_tactic SKIPPED (Rule loader failure)                                                                                                   [ 30%]
tests/test_all_rules.py::TestRuleMetadata::test_deprecated_rules SKIPPED (Rule loader failure)                                                                                                     [ 32%]
tests/test_all_rules.py::TestRuleMetadata::test_event_dataset SKIPPED (Rule loader failure)                                                                                                        [ 34%]
tests/test_all_rules.py::TestRuleMetadata::test_integration_tag SKIPPED (Rule loader failure)                                                                                                      [ 36%]
tests/test_all_rules.py::TestRuleMetadata::test_invalid_queries SKIPPED (Rule loader failure)                                                                                                      [ 38%]
tests/test_all_rules.py::TestRuleMetadata::test_updated_date_newer_than_creation SKIPPED (Rule loader failure)                                                                                     [ 40%]
tests/test_all_rules.py::TestRuleTags::test_casing_and_spacing SKIPPED (Rule loader failure)                                                                                                       [ 42%]
tests/test_all_rules.py::TestRuleTags::test_investigation_guide_tag SKIPPED (Skipping until all Investigation Guides follow the proper format.)                                                    [ 44%]
tests/test_all_rules.py::TestRuleTags::test_ml_rule_type_tags SKIPPED (Rule loader failure)                                                                                                        [ 46%]
tests/test_all_rules.py::TestRuleTags::test_no_duplicate_tags SKIPPED (Rule loader failure)                                                                                                        [ 48%]
tests/test_all_rules.py::TestRuleTags::test_os_tags SKIPPED (Rule loader failure)                                                                                                                  [ 50%]
tests/test_all_rules.py::TestRuleTags::test_primary_tactic_as_tag SKIPPED (Rule loader failure)                                                                                                    [ 51%]
tests/test_all_rules.py::TestRuleTags::test_required_tags SKIPPED (Rule loader failure)                                                                                                            [ 53%]
tests/test_all_rules.py::TestRuleTags::test_tag_prefix SKIPPED (Rule loader failure)                                                                                                               [ 55%]
tests/test_all_rules.py::TestRuleTimelines::test_timeline_has_title SKIPPED (Rule loader failure)                                                                                                  [ 57%]
tests/test_all_rules.py::TestRuleTiming::test_eql_interval_to_maxspan SKIPPED (Rule loader failure)                                                                                                [ 59%]
tests/test_all_rules.py::TestRuleTiming::test_eql_lookback SKIPPED (Rule loader failure)                                                                                                           [ 61%]
tests/test_all_rules.py::TestRuleTiming::test_event_override SKIPPED (Rule loader failure)                                                                                                         [ 63%]
tests/test_all_rules.py::TestRuleTiming::test_required_lookback SKIPPED (Rule loader failure)                                                                                                      [ 65%]
tests/test_all_rules.py::TestThreatMappings::test_duplicated_tactics SKIPPED (Rule loader failure)                                                                                                 [ 67%]
tests/test_all_rules.py::TestThreatMappings::test_tactic_to_technique_correlations SKIPPED (Rule loader failure)                                                                                   [ 69%]
tests/test_all_rules.py::TestThreatMappings::test_technique_deprecations SKIPPED (Rule loader failure)                                                                                             [ 71%]
tests/test_all_rules.py::TestValidRules::test_all_rule_queries_optimized SKIPPED (Rule loader failure)                                                                                             [ 73%]
tests/test_all_rules.py::TestValidRules::test_bbr_validation SKIPPED (Rule loader failure)                                                                                                         [ 75%]
tests/test_all_rules.py::TestValidRules::test_duplicate_file_names SKIPPED (Rule loader failure)                                                                                                   [ 76%]
tests/test_all_rules.py::TestValidRules::test_file_names SKIPPED (Rule loader failure)                                                                                                             [ 78%]
tests/test_all_rules.py::TestValidRules::test_production_rules_have_rta SKIPPED (Rule loader failure)                                                                                              [ 80%]
tests/test_all_rules.py::TestValidRules::test_rule_type_changes SKIPPED (Rule loader failure)                                                                                                      [ 82%]
tests/test_all_rules.py::TestValidRules::test_schema_and_dupes SKIPPED (Rule loader failure)                                                                                                       [ 84%]
tests/test_mappings.py::TestRTAs::test_rtas_with_triggered_rules_have_uuid PASSED                                                                                                                  [ 86%]
tests/test_specific_rules.py::TestESQLRules::test_esql_queries SKIPPED (Rule loader failure)                                                                                                       [ 88%]
tests/test_specific_rules.py::TestEndpointQuery::test_os_and_platform_in_query SKIPPED (Rule loader failure)                                                                                       [ 90%]
tests/test_specific_rules.py::TestNewTerms::test_history_window_start SKIPPED (Rule loader failure)                                                                                                [ 92%]
tests/test_specific_rules.py::TestNewTerms::test_new_terms_field_exists SKIPPED (Rule loader failure)                                                                                              [ 94%]
tests/test_specific_rules.py::TestNewTerms::test_new_terms_fields SKIPPED (Rule loader failure)                                                                                                    [ 96%]
tests/test_specific_rules.py::TestNewTerms::test_new_terms_fields_unique SKIPPED (Rule loader failure)                                                                                             [ 98%]
tests/test_specific_rules.py::TestNewTerms::test_new_terms_max_limit SKIPPED (Rule loader failure)                                                                                                 [100%]
```

</details>


#### 3. `CUSTOM_RULES_DIR=custom-rules make test` 

- with the settings for `testing.config` set to `etc/test_config.yaml`
```yaml
testing:
  config: etc/test_config.yaml
```
 - This tests custom rules against a custom testing config

A config directory is [attached](https://github.com/brokensound77/detection-rules/pull/4#issuecomment-1918006677) for convenience